### PR TITLE
Add day-of notifications for generated recurring expenses

### DIFF
--- a/FinanceTracker/Helpers/AppConfiguration.swift
+++ b/FinanceTracker/Helpers/AppConfiguration.swift
@@ -35,7 +35,24 @@ enum SmartTaggingMode: String, CaseIterable {
 class AppConfiguration {
     private let defaults: UserDefaults
     private let cloudKVS = NSUbiquitousKeyValueStore.default
-    private let suite = "group.me.enzottic.SageAppGroup"
+    private static let suite = "group.me.enzottic.SageAppGroup"
+
+    /// The defaults store local-only flags are persisted to. DEBUG uses .standard to match
+    /// init(); release uses the shared app-group suite so widgets and background tasks read
+    /// the same values the app writes.
+    static var localDefaults: UserDefaults {
+        #if DEBUG
+        .standard
+        #else
+        UserDefaults(suiteName: suite) ?? .standard
+        #endif
+    }
+
+    /// Reads the persisted flag without an AppConfiguration instance (background tasks,
+    /// non-view call sites).
+    static var isBillRemindersEnabled: Bool {
+        localDefaults.bool(forKey: Keys.billRemindersEnabled)
+    }
     
     // Keys used in both UserDefaults and iCloud KVS
     private enum Keys {
@@ -164,11 +181,7 @@ class AppConfiguration {
     }
     
     init() {
-        #if DEBUG
-        self.defaults = .standard
-        #else
-        self.defaults = UserDefaults(suiteName: suite) ?? .standard
-        #endif
+        self.defaults = Self.localDefaults
         
         // iCloud KVS is the source of truth for all settings.
         // Fall back to local UserDefaults if iCloud KVS hasn't synced yet.

--- a/FinanceTracker/SageApp.swift
+++ b/FinanceTracker/SageApp.swift
@@ -10,6 +10,7 @@ import SwiftData
 import AppIntents
 import SageKit
 import Combine
+import UserNotifications
 
 @main
 struct SageApp: App {
@@ -26,6 +27,9 @@ struct SageApp: App {
 
         // Register before the app finishes launching (BGTaskScheduler requirement)
         RecurringNotificationService.registerBackgroundTask()
+
+        // Present notifications that fire while the app is foreground
+        UNUserNotificationCenter.current().delegate = NotificationDelegate.shared
 
         // Make ExpenseStore resolvable via @Dependency in App Intents.
         AppDependencyManager.shared.add(dependency: ExpenseStore.shared)

--- a/FinanceTracker/Services/NotificationDelegate.swift
+++ b/FinanceTracker/Services/NotificationDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  NotificationDelegate.swift
+//  FinanceTracker
+//
+
+import UserNotifications
+
+/// Without a delegate, iOS silently drops notifications that fire while the app is foreground.
+final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = NotificationDelegate()
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
+    }
+}

--- a/FinanceTracker/Services/RecurringNotificationService.swift
+++ b/FinanceTracker/Services/RecurringNotificationService.swift
@@ -15,6 +15,7 @@ enum RecurringNotificationService {
     static let bgTaskIdentifier = "me.enzottic.sage.recurringRefresh"
     private static let center = UNUserNotificationCenter.current()
     private static let notificationIDPrefix = "recurring-day-"
+    private static let addedNotificationIDPrefix = "recurring-added-"
 
     // MARK: - Authorization
 
@@ -32,9 +33,11 @@ enum RecurringNotificationService {
     /// Grouping by day means multiple bills landing on the same date produce a single notification,
     /// and slot usage is bounded by due dates rather than rule count.
     static func scheduleAll(rules: [RecurringExpenseRule], enabled: Bool) async {
-        // Remove every previously scheduled recurring-day notification
+        // Remove every previously scheduled recurring notification
         let pending = await center.pendingNotificationRequests()
-        let staleIDs = pending.map(\.identifier).filter { $0.hasPrefix(notificationIDPrefix) }
+        let staleIDs = pending.map(\.identifier).filter {
+            $0.hasPrefix(notificationIDPrefix) || $0.hasPrefix(addedNotificationIDPrefix)
+        }
         center.removePendingNotificationRequests(withIdentifiers: staleIDs)
 
         guard enabled else { return }
@@ -52,7 +55,16 @@ enum RecurringNotificationService {
 
         for (day, dayRules) in byDay {
             await scheduleNotification(dueDate: day, rules: dayRules)
+            await scheduleAddedNotification(dueDate: day, rules: dayRules)
         }
+    }
+
+    /// Re-fetches all rules and re-schedules notifications. For call sites that don't
+    /// have an AppConfiguration instance or a fresh rule list handy (rule create/edit,
+    /// background refresh).
+    static func rescheduleAll(modelContext: ModelContext) async {
+        let rules = (try? modelContext.fetch(FetchDescriptor<RecurringExpenseRule>())) ?? []
+        await scheduleAll(rules: rules, enabled: AppConfiguration.isBillRemindersEnabled)
     }
 
     // MARK: - Background Task
@@ -72,10 +84,7 @@ enum RecurringNotificationService {
                     let service = RecurringExpenseService(modelContext: context)
                     service.generateAllExpenses(through: Date())
 
-                    let rules = (try? context.fetch(FetchDescriptor<RecurringExpenseRule>())) ?? []
-                    let enabled = UserDefaults(suiteName: SageModelContainer.appGroupIdentifier)?
-                        .bool(forKey: "billRemindersEnabled") ?? false
-                    await scheduleAll(rules: rules, enabled: enabled)
+                    await rescheduleAll(modelContext: context)
                 } catch {}
 
                 scheduleNextBackgroundRefresh()
@@ -121,10 +130,49 @@ enum RecurringNotificationService {
         try? await center.add(request)
     }
 
+    /// Fires at 9 AM on the due date itself, announcing the expenses generated for that day.
+    /// The row may be inserted slightly later (next launch or background refresh), but it is
+    /// dated to this day. If 9 AM has already passed, skip — the user will see the expense
+    /// generated on next launch anyway.
+    private static func scheduleAddedNotification(dueDate: Date, rules: [RecurringExpenseRule]) async {
+        var components = Calendar.current.dateComponents([.year, .month, .day], from: dueDate)
+        components.hour = 9
+        components.minute = 0
+        guard let fireDate = Calendar.current.date(from: components), fireDate > Date() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.sound = .default
+        content.threadIdentifier = "recurring-added"
+
+        if rules.count == 1, let rule = rules.first {
+            content.title = "Recurring Expense Added"
+            content.body = "\(rule.name) (\(rule.amount.currencyStringWithFraction)) was added."
+        } else {
+            content.title = "\(rules.count) Recurring Expenses Added"
+            content.body = rules
+                .map { "\($0.name) (\($0.amount.currencyStringWithFraction))" }
+                .joined(separator: ", ")
+        }
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: addedNotificationID(for: dueDate),
+            content: content,
+            trigger: trigger
+        )
+        try? await center.add(request)
+    }
+
     private static func notificationID(for day: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         return "\(notificationIDPrefix)\(formatter.string(from: day))"
+    }
+
+    private static func addedNotificationID(for day: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return "\(addedNotificationIDPrefix)\(formatter.string(from: day))"
     }
 
     private static func nextOccurrence(for rule: RecurringExpenseRule) -> Date? {

--- a/FinanceTracker/Views/Components/AddExpenseView.swift
+++ b/FinanceTracker/Views/Components/AddExpenseView.swift
@@ -339,6 +339,9 @@ struct AddExpenseView: View {
             WidgetCenter.shared.reloadAllTimelines()
             dismiss()
             appRouter.showToast(SageToast(message: "Expense saved", kind: .success))
+            if isRecurring {
+                await RecurringNotificationService.rescheduleAll(modelContext: modelContext)
+            }
         } catch {
             isSaving = false
             errorMessage = "Failed to save expense: \(error.localizedDescription)"

--- a/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
+++ b/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
@@ -123,6 +123,9 @@ struct EditRecurringRuleSheet: View {
         do {
             try modelContext.save()
             WidgetCenter.shared.reloadAllTimelines()
+            Task {
+                await RecurringNotificationService.rescheduleAll(modelContext: modelContext)
+            }
             dismiss()
         } catch {
             errorMessage = "Failed to save: \(error.localizedDescription)"

--- a/FinanceTracker/Views/SettingsView/Components/RecurringExpensesSettingsSection.swift
+++ b/FinanceTracker/Views/SettingsView/Components/RecurringExpensesSettingsSection.swift
@@ -69,7 +69,7 @@ struct RecurringExpensesSettingsSection: View {
                         }
                     }
                 } else {
-                    Text("Get notified at 9 AM the day before each bill is due.")
+                    Text("Get notified at 9 AM the day before each bill is due, and on the day each recurring expense is added.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
## Summary
Notifies the user when a recurring expense is generated ("Netflix ($15.99) was added."). Instead of firing when generation actually inserts the row — which depends on iOS running the opportunistic `BGAppRefreshTask` and could be days late — the notification is **pre-scheduled with a `UNCalendarNotificationTrigger` for 9 AM on each occurrence date**, the same pattern as the existing "Bill Due Tomorrow" reminders. The expense row itself is backfilled by the next launch or background refresh, dated to that day.

## Changes
- **RecurringNotificationService**: `scheduleAll` now schedules a second, date-keyed notification per due day (`recurring-added-yyyy-MM-dd`, batched when multiple rules land on the same day) and cleans up both id prefixes. New `rescheduleAll(modelContext:)` convenience wraps the fetch-rules + read-toggle + schedule dance; the BG task handler now uses it.
- **Reschedule on rule create/edit**: `AddExpenseView` and `EditRecurringRuleSheet` re-run scheduling after saving — previously a new or edited rule's notifications waited for the next app launch (this gap also affected the existing due-tomorrow reminders).
- **NotificationDelegate** (new): minimal `willPresent` → `[.banner, .sound]` so notifications firing while the app is foreground aren't silently dropped; registered in `SageApp.init()`.
- **AppConfiguration.localDefaults**: single source of truth for the local-flags store (`.standard` in DEBUG, app-group suite in release). Fixes DEBUG builds writing `billRemindersEnabled` to `.standard` while the BG task handler read the app-group suite — background simulation in DEBUG always saw the feature disabled.
- Day-of alerts share the existing **Bill Reminders** toggle; settings caption updated.

No Info.plist, entitlement, or schema changes.

## Testing
- Builds clean with the Xcode 27 beta toolchain (`generic/platform=iOS Simulator`, Debug).
- Manual verification steps (per plan): pending-request inspection after creating a rule (`recurring-day-*` + `recurring-added-*` both present), batching with two same-day rules, no duplicates across relaunches (date-keyed ids replace), cleanup on toggle-off and rule deletion, BG path via
  `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"me.enzottic.sage.recurringRefresh"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)