### PR TITLE
Fix receipt capture availability

### DIFF
--- a/FinanceTracker/Services/ReceiptParserService.swift
+++ b/FinanceTracker/Services/ReceiptParserService.swift
@@ -14,64 +14,97 @@ import SageKit
 class ReceiptParserService {
     init() {}
 
-    func parseReceipt(image: UIImage, tags: [ExpenseTag]) async -> ParsedExpense? {
-        let text = await recgonizeTextInImage(image: image)
-        guard text.isEmpty == false else { return nil }
+    func parseReceipt(image: UIImage, tags: [ExpenseTag]) async throws -> ParsedExpense {
+        guard SystemLanguageModel.default.isAvailable else {
+            throw ReceiptParserError.languageModelUnavailable
+        }
 
-        return await extractExpenseDataFromText(receiptText: text, tags: tags)
+        let text = try await recognizeTextInImage(image: image)
+
+        return try await extractExpenseDataFromText(receiptText: text, tags: tags)
     }
 
     // Uses the Vision framework to pull text out of the image
-    private func recgonizeTextInImage(image: UIImage) async  -> String {
-        var text: String = ""
+    private func recognizeTextInImage(image: UIImage) async throws -> String {
+        guard let imageData = image.pngData() else {
+            throw ReceiptParserError.imageEncodingFailed
+        }
+
         var request = RecognizeTextRequest()
         request.recognitionLevel = .accurate
 
-        if let imageData = image.pngData(),
-            let results = try? await request.perform(on: imageData) {
-            for observation in results {
-                let candidate = observation.topCandidates(1)
-                if let observedText = candidate.first?.string {
-                    text += "\n\(observedText)"
-                }
-            }
+        let results: [RecognizedTextObservation]
+        do {
+            results = try await request.perform(on: imageData)
+        } catch {
+            throw ReceiptParserError.textRecognitionFailed
+        }
+
+        let text = results.compactMap { observation in
+            observation.topCandidates(1).first?.string
+        }
+        .joined(separator: "\n")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !text.isEmpty else {
+            throw ReceiptParserError.noTextFound
         }
 
         return text
     }
 
-
-    // Uses a local AI model from FoundationModels framework to generate a parsed expense object, using the raw text
-    // pulled from the receipt as input
-    private func extractExpenseDataFromText(receiptText: String, tags: [ExpenseTag]) async -> ParsedExpense? {
+    // Uses a local AI model to generate an expense from the recognized receipt text.
+    private func extractExpenseDataFromText(receiptText: String, tags: [ExpenseTag]) async throws -> ParsedExpense {
         let instructions = Instructions("""
-You are an experienced expense categorizer. You are given a string of text that has been recgonized from
-an receipt. You are to determine the following information from the text:
+You are an experienced expense categorizer. You are given a string of text that was recognized from
+a receipt. You are to determine the following information from the receipt:
 1. The total price of the item purchased (MOST IMPORTANT)
 2. The name of what was purchased. For example, if you see a grocery receipt, you would note "Groceries". If you see a receipt for a TV, you would say "TV". The name of the store would suffice as well if you cannot determine the exact item or if there are multiple items.
-3. The category of what this item/purchase would generally be. There are only two options: Needs or Wants. Needs describe expenses that are needed/must be spent. This includes things like rent, groceries, utility bills, and other payments. Wants are things that are not needed and are leisure spends, such as new devices, eating out, shopping, clothes, etc. Pick which one best fits the receipt.
-4. The date the transaction occured on. If no date is found, do NOT provide a date at all.
-5. A tag that further describes the expense. You MUST pick EXACTLY ONE tag ONLY from the list provided. DO NOT respond with any other tag other than ones in the provided list that follows 'Available Tags'. If no tags match close enough, do not respond with ANY tag.
+3. The category of what this item/purchase would generally be. There are only two options: Needs or Wants. Needs describe expenses that are needed/must be spent. This includes rent, groceries, utility bills, and other payments. Wants are not needed and are leisure spends, such as new devices, eating out, shopping, and clothes. Pick the best option for the receipt.
+4. The date the transaction occurred on. If no date is found, do NOT provide a date.
+5. A tag that further describes the expense. You MUST pick EXACTLY ONE tag ONLY from the provided list. If no tag matches, do not provide a tag.
 """)
         let session = LanguageModelSession(instructions: instructions)
         let prompt = "Receipt Text: \(receiptText). Available Tags: \(tags.compactMap { $0.name }.joined(separator: ","))"
-        print(prompt)
-        
+
         do {
             let response = try await session.respond(to: prompt, generating: ParsedExpense.self)
             return response.content
         } catch {
-            return nil
+            throw ReceiptParserError.parsingFailed
         }
     }
 }
 
-    
+@available(iOS 26.0, *)
+enum ReceiptParserError: LocalizedError {
+    case languageModelUnavailable
+    case imageEncodingFailed
+    case textRecognitionFailed
+    case noTextFound
+    case parsingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .languageModelUnavailable:
+            "Receipt reading requires Apple Intelligence on this device."
+        case .imageEncodingFailed:
+            "Sage couldn't prepare this photo. Choose another photo and try again."
+        case .textRecognitionFailed:
+            "Sage couldn't read text from this photo. Try a clearer photo of the full receipt."
+        case .noTextFound:
+            "Sage couldn't find receipt text in this photo. Try a clearer photo of the full receipt."
+        case .parsingFailed:
+            "Sage couldn't read this receipt. Try again later."
+        }
+    }
+}
+
 @available(iOS 26.0, *)
 @Generable(description: "A collection of details for an expense parsed from a receipt")
 struct ParsedExpense {
     @Guide(description: "A short description of the expense, or where the expense came from. You should try to be as descriptive as possible in as little words as possible. For example, if the receipt seems to be a grocery receipt and is from the store 'Safeway', you would respond with 'Safeway'.")
-let name: String
+    let name: String
     @Guide(description: "The total price of goods stated on the receipt. You may seem an itemized receipt with individual charges, and then a total charge. In general, the price you will note down is the highest price you see from the receipt text.")
     let price: Double
     @Guide(description: "The date the the transaction occured on, in YYYY-MM-DD format. YOU MUST RESPOND IN THIS FORMAT. If no date can be found, do not return a date.")

--- a/FinanceTracker/Views/Components/AddExpenseView.swift
+++ b/FinanceTracker/Views/Components/AddExpenseView.swift
@@ -9,6 +9,7 @@ import SwiftData
 import WidgetKit
 import PhotosUI
 import UIKit
+import FoundationModels
 import SageKit
 
 struct AddExpenseView: View {
@@ -44,8 +45,31 @@ struct AddExpenseView: View {
         }
     }
 
-    private var receiptImportEnabled: Bool {
-        if #available(iOS 26.0, *) { true } else { false }
+    private var receiptImportUnavailableMessage: String? {
+        if #available(iOS 26.0, *) {
+            return SystemLanguageModel.default.isAvailable
+                ? nil
+                : "Receipt reading requires Apple Intelligence on this device."
+        }
+
+        return "Receipt reading requires iOS 26 or later."
+    }
+
+    private var receiptImportConfiguration: ReceiptImportConfiguration? {
+        guard receiptImportUnavailableMessage == nil else { return nil }
+
+        return ReceiptImportConfiguration(
+            isParsing: isParsingReceipt,
+            canUseCamera: UIImagePickerController.isSourceTypeAvailable(.camera),
+            onTakePhoto: {
+                guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+                    showReceiptError("This device does not have a camera. Choose a photo from your library instead.")
+                    return
+                }
+                showCamera = true
+            },
+            onChoosePhoto: { showPhotoLibrary = true }
+        )
     }
 
     var body: some View {
@@ -58,13 +82,8 @@ struct AddExpenseView: View {
                     category: $category,
                     tags: $tags,
                     note: $note,
-                    receiptImport: receiptImportEnabled
-                        ? ReceiptImportConfiguration(
-                            isParsing: isParsingReceipt,
-                            onTakePhoto: { showCamera = true },
-                            onChoosePhoto: { showPhotoLibrary = true }
-                        )
-                        : nil
+                    receiptImport: receiptImportConfiguration,
+                    receiptImportUnavailableMessage: receiptImportUnavailableMessage
                 )
 
                 optionsCard
@@ -106,9 +125,12 @@ struct AddExpenseView: View {
             Task { await loadReceiptPhoto(item) }
         }
         .fullScreenCover(isPresented: $showCamera) {
-            CameraPickerView { image in
-                Task { await parseReceipt(image) }
-            }
+            CameraPickerView(
+                onImagePicked: { image in
+                    Task { await parseReceipt(image) }
+                },
+                onFailure: showReceiptError
+            )
             .ignoresSafeArea()
         }
         .gradientBackground()
@@ -184,7 +206,7 @@ struct AddExpenseView: View {
 
             await parseReceipt(image)
         } catch {
-            showReceiptError("Sage couldn't open that photo: \(error.localizedDescription)")
+            showReceiptError("Sage couldn't open that photo. Choose another photo and try again.")
         }
     }
 
@@ -193,29 +215,33 @@ struct AddExpenseView: View {
         isParsingReceipt = true
         defer { isParsingReceipt = false }
 
+        guard receiptImportUnavailableMessage == nil else {
+            showReceiptError(receiptImportUnavailableMessage ?? "Receipt reading is unavailable.")
+            return
+        }
+
         if #available(iOS 26.0, *) {
-            let service = ReceiptParserService()
-            guard let parsed = await service.parseReceipt(image: image, tags: allTags) else {
-                showReceiptError("Sage couldn't read this receipt. Try a clearer photo.")
-                return
+            do {
+                let parsed = try await ReceiptParserService().parseReceipt(image: image, tags: allTags)
+                name = parsed.name
+                amount = parsed.price
+
+                if let dateStr = parsed.date {
+                    let formatter = DateFormatter()
+                    formatter.dateFormat = "yyyy-MM-dd"
+                    date = formatter.date(from: dateStr) ?? .now
+                }
+
+                category = parsed.category.lowercased() == "needs" ? .needs : .wants
+
+                if let tagName = parsed.tag, let matched = allTags.first(where: { $0.name == tagName }) {
+                    tags = [matched]
+                }
+            } catch let error as ReceiptParserError {
+                showReceiptError(error.localizedDescription)
+            } catch {
+                showReceiptError("Sage couldn't read this receipt. Try again later.")
             }
-
-            name = parsed.name
-            amount = parsed.price
-
-            if let dateStr = parsed.date {
-                let formatter = DateFormatter()
-                formatter.dateFormat = "yyyy-MM-dd"
-                date = formatter.date(from: dateStr) ?? .now
-            }
-
-            category = parsed.category.lowercased() == "needs" ? .needs : .wants
-
-            if let tagName = parsed.tag, let matched = allTags.first(where: { $0.name == tagName }) {
-                tags = [matched]
-            }
-        } else {
-            showReceiptError("Receipt reading requires iOS 26 or later.")
         }
     }
 

--- a/FinanceTracker/Views/Components/CameraPickerView.swift
+++ b/FinanceTracker/Views/Components/CameraPickerView.swift
@@ -8,6 +8,7 @@ import UIKit
 
 struct CameraPickerView: UIViewControllerRepresentable {
     let onImagePicked: (UIImage) -> Void
+    let onFailure: (String) -> Void
 
     @Environment(\.dismiss) private var dismiss
 
@@ -17,7 +18,7 @@ struct CameraPickerView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
-        picker.sourceType = UIImagePickerController.isSourceTypeAvailable(.camera) ? .camera : .photoLibrary
+        picker.sourceType = .camera
         picker.delegate = context.coordinator
         return picker
     }
@@ -37,6 +38,8 @@ struct CameraPickerView: UIViewControllerRepresentable {
         ) {
             if let image = info[.originalImage] as? UIImage {
                 parent.onImagePicked(image)
+            } else {
+                parent.onFailure("Sage couldn't open this camera photo. Try again.")
             }
             parent.dismiss()
         }

--- a/FinanceTracker/Views/Components/ExpenseInfoForm.swift
+++ b/FinanceTracker/Views/Components/ExpenseInfoForm.swift
@@ -11,6 +11,7 @@ import SageKit
 
 struct ReceiptImportConfiguration {
     let isParsing: Bool
+    let canUseCamera: Bool
     let onTakePhoto: () -> Void
     let onChoosePhoto: () -> Void
 }
@@ -29,6 +30,7 @@ struct ExpenseInfoForm: View {
     @Binding var note: String
     var isEditing: Bool
     var receiptImport: ReceiptImportConfiguration?
+    var receiptImportUnavailableMessage: String?
 
     private let tagSuggestionService = TagSuggestionService()
     @FocusState private var focusedField: Field?
@@ -62,7 +64,8 @@ struct ExpenseInfoForm: View {
         tags: Binding<[ExpenseTag]>,
         note: Binding<String>,
         isEditing: Bool = false,
-        receiptImport: ReceiptImportConfiguration? = nil
+        receiptImport: ReceiptImportConfiguration? = nil,
+        receiptImportUnavailableMessage: String? = nil
     ) {
         self._name = name
         self._amount = amount
@@ -72,6 +75,7 @@ struct ExpenseInfoForm: View {
         self._note = note
         self.isEditing = isEditing
         self.receiptImport = receiptImport
+        self.receiptImportUnavailableMessage = receiptImportUnavailableMessage
     }
 
     var body: some View {
@@ -123,6 +127,12 @@ struct ExpenseInfoForm: View {
 
             if !isEditing, let receiptImport {
                 receiptButton(receiptImport)
+            } else if !isEditing, let receiptImportUnavailableMessage {
+                Text(receiptImportUnavailableMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+                    .frame(maxWidth: 144)
             }
         }
         .padding(.horizontal)
@@ -130,7 +140,9 @@ struct ExpenseInfoForm: View {
 
     private func receiptButton(_ configuration: ReceiptImportConfiguration) -> some View {
         Menu {
-            Button("Take Photo", systemImage: "camera", action: configuration.onTakePhoto)
+            if configuration.canUseCamera {
+                Button("Take Photo", systemImage: "camera", action: configuration.onTakePhoto)
+            }
             Button(
                 "Choose from Photos",
                 systemImage: "photo.on.rectangle",


### PR DESCRIPTION
## Summary
- Hide receipt parsing when Apple Intelligence is unavailable and show the reason.
- Remove the camera picker photo-library fallback and keep PhotosPicker for library imports.
- Report clear image, text-recognition, and parsing errors.

## Tests
- `xcodebuild -project FinanceTracker.xcodeproj -scheme FinanceTracker -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /private/tmp/sage-deriveddata-focused -only-testing:FinanceTrackerUITests/ExpenseCSVCodecTests -parallel-testing-enabled NO test CODE_SIGNING_ALLOWED=NO -quiet` (9 passed)

Closes #21.