### PR TITLE
Fix calendar-day comparisons for upcoming expense labels

### DIFF
--- a/APP_STORE_READINESS.md
+++ b/APP_STORE_READINESS.md
@@ -234,9 +234,13 @@ distribution, and App Store Connect checks remain open without execution evidenc
   Sources: [monthly overview](FinanceTracker/Views/DashboardView/Widgets/MonthlyOverviewWidget.swift),
   [Stats summary](SageKit/Analytics/SpendingMonthSummary.swift).
 
-- [ ] **Use calendar-day comparisons for upcoming labels.** A charge tomorrow
-  morning can say "today" tonight when fewer than 24 hours remain. Compare
-  calendar days rather than whole elapsed days.
+- [x] **Use calendar-day comparisons for upcoming labels.** Both surfaces now
+  compare start-of-day dates in the display calendar through `UpcomingExpenseDays`,
+  including the three-day highlighting threshold. Regression coverage in
+  `UpcomingExpenseDaysTests` includes midnight, past dates, multi-day thresholds,
+  daylight-saving changes, and display time zones. All 6 tests (12 cases) passed
+  using the exact helper and test sources in a standalone macOS Swift package.
+  Simulator verification was intentionally skipped at the user's request (#57).
   Sources: [upcoming widget](FinanceTracker/Views/DashboardView/Widgets/UpcomingRecurringWidget.swift),
   [recurring settings](FinanceTracker/Views/SettingsView/Components/RecurringExpensesSettingsSection.swift).
 

--- a/FinanceTracker/Views/DashboardView/Widgets/UpcomingRecurringWidget.swift
+++ b/FinanceTracker/Views/DashboardView/Widgets/UpcomingRecurringWidget.swift
@@ -112,7 +112,7 @@ private struct UpcomingRecurringCard: View {
     let nextDate: Date
 
     private var daysAway: Int {
-        max(0, Calendar.current.dateComponents([.day], from: .now, to: nextDate).day ?? 0)
+        UpcomingExpenseDays.count(until: nextDate)
     }
 
     private var isImminent: Bool { daysAway <= 3 }

--- a/FinanceTracker/Views/SettingsView/Components/RecurringExpensesSettingsSection.swift
+++ b/FinanceTracker/Views/SettingsView/Components/RecurringExpensesSettingsSection.swift
@@ -215,14 +215,14 @@ private struct RecurringRuleRow: View {
     }
 
     private func daysLabel(for date: Date) -> String {
-        let days = max(0, Calendar.current.dateComponents([.day], from: .now, to: date).day ?? 0)
+        let days = UpcomingExpenseDays.count(until: date)
         if days == 0 { return "today" }
         if days == 1 { return "in 1 day" }
         return "in \(days) days"
     }
 
     private func isImminent(_ date: Date) -> Bool {
-        let days = Calendar.current.dateComponents([.day], from: .now, to: date).day ?? 0
+        let days = UpcomingExpenseDays.count(until: date)
         return days <= 3
     }
 }

--- a/FinanceTrackerTests/UpcomingExpenseDaysTests.swift
+++ b/FinanceTrackerTests/UpcomingExpenseDaysTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import SageKit
+
+@Suite("Upcoming expense days")
+struct UpcomingExpenseDaysTests {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        return calendar
+    }
+
+    private func date(month: Int = 9, day: Int, hour: Int = 0, minute: Int = 0) throws -> Date {
+        try #require(calendar.date(from: DateComponents(
+            year: 2026, month: month, day: day, hour: hour, minute: minute
+        )))
+    }
+
+    @Test
+    func laterTodayIsZeroDaysAway() throws {
+        let now = try date(day: 7, hour: 8)
+        let due = try date(day: 7, hour: 23)
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: calendar) == 0)
+    }
+
+    @Test
+    func crossingMidnightCountsAsTomorrow() throws {
+        let now = try date(day: 7, hour: 23, minute: 55)
+        let due = try date(day: 8)
+        #expect(due.timeIntervalSince(now) == 5 * 60)
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: calendar) == 1)
+    }
+
+    @Test(arguments: [2, 3, 4, 7])
+    func countsCalendarDaysAtUpcomingThresholds(days: Int) throws {
+        let now = try date(day: 7, hour: 23)
+        let due = try date(day: 7 + days)
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: calendar) == days)
+    }
+
+    @Test(arguments: [1, 6, 7])
+    func pastDatesAreClampedToZero(day: Int) throws {
+        let now = try date(day: 7, hour: 12)
+        let due = try date(day: day)
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: calendar) == 0)
+    }
+
+    @Test(arguments: [(3, 8, 23), (11, 1, 25)])
+    func daylightSavingDaysCountAsOneDay(month: Int, day: Int, hours: Int) throws {
+        let now = try date(month: month, day: day)
+        let due = try date(month: month, day: day + 1)
+        #expect(due.timeIntervalSince(now) == Double(hours * 3600))
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: calendar) == 1)
+    }
+
+    @Test
+    func usesTheSuppliedCalendarTimeZone() throws {
+        let now = try date(day: 7, hour: 23, minute: 55)
+        let due = try date(day: 8)
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: calendar) == 1)
+        #expect(UpcomingExpenseDays.count(until: due, from: now, calendar: utc) == 0)
+    }
+}

--- a/SageKit/Utilities/UpcomingExpenseDays.swift
+++ b/SageKit/Utilities/UpcomingExpenseDays.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Days until an expense in the display calendar, independent of its scheduled time.
+public enum UpcomingExpenseDays {
+    public static func count(until date: Date, from now: Date = .now, calendar: Calendar = .current) -> Int {
+        max(0, calendar.dateComponents(
+            [.day],
+            from: calendar.startOfDay(for: now),
+            to: calendar.startOfDay(for: date)
+        ).day ?? 0)
+    }
+}


### PR DESCRIPTION
A recurring charge tomorrow could appear as “today” when fewer than 24 hours remained. Use a shared calendar-day calculation for dashboard and recurring settings labels, accessibility descriptions, and the three-day highlighting threshold. Update the readiness checklist.

Validation: all 6 tests (12 cases) passed with the exact helper and test sources in a standalone macOS Swift package, covering midnight, multi-day thresholds, past dates, daylight-saving changes, and display time zones. `git diff --check` passed. iOS build and simulator tests were not run; simulator testing was skipped at the user's request.

Closes #57
