### PR TITLE
Protect changed editor drafts

### DIFF
--- a/APP_STORE_READINESS.md
+++ b/APP_STORE_READINESS.md
@@ -261,10 +261,12 @@ distribution, and App Store Connect checks remain open without execution evidenc
 
 ## Priority 2: Polish And Accessibility
 
-- [ ] **Protect changed drafts on dismissal and navigation.** Add discard
-  confirmation or draft preservation for expense/tag/rule editors. Include
-  swipe dismissal, Cancel, back navigation, and Home's Show All action clearing
-  the Expenses stack. Do not prompt for untouched forms.
+- [x] **Protect changed drafts on dismissal and navigation.** Changed expense,
+  tag, and recurring-rule forms require discard confirmation on Cancel and
+  custom back navigation; sheet swipe dismissal is disabled while changed.
+  Untouched forms exit directly.
+  The router defers Home's Show All stack clear to the active expense editor,
+  which can keep editing or discard before navigation continues (#60).
   Sources: [expense creation](FinanceTracker/Views/Components/AddExpenseView.swift),
   [expense editor](FinanceTracker/Views/Components/ExpenseDetailView.swift),
   [router](FinanceTracker/Router/AppRouter.swift).

--- a/FinanceTracker/Router/AppRouter.swift
+++ b/FinanceTracker/Router/AppRouter.swift
@@ -28,10 +28,19 @@ final class AppRouter {
     var toast: SageToast?
 
     private var dismissTask: Task<Void, Never>?
+    var expenseDraftNavigationHandler: ((Date) -> Void)?
 
     // MARK: - Navigation
 
     func showExpenses(for month: Date) {
+        if let expenseDraftNavigationHandler {
+            expenseDraftNavigationHandler(month)
+            return
+        }
+        completeShowExpenses(for: month)
+    }
+
+    func completeShowExpenses(for month: Date) {
         expensesMonth = month
         expensesPath.removeAll()
         expensesRequestID = UUID()

--- a/FinanceTracker/Views/Components/AddExpenseView.swift
+++ b/FinanceTracker/Views/Components/AddExpenseView.swift
@@ -21,6 +21,7 @@ struct AddExpenseView: View {
     @State private var name: String = ""
     @State private var amount: Double? = nil
     @State private var date: Date = Date.now
+    @State private var initialDate: Date = Date.now
     @State private var category: ExpenseCategory = .needs
     @State private var tags: [ExpenseTag] = []
     @State private var note: String = ""
@@ -33,6 +34,7 @@ struct AddExpenseView: View {
     @State private var keyboardDismissalRequest = 0
     @State private var debouncedName = ""
     @State private var nameDebounceTask: Task<Void, Never>?
+    @State private var showDiscardConfirmation = false
 
     @State private var isParsingReceipt: Bool = false
     @State private var showCamera = false
@@ -45,6 +47,9 @@ struct AddExpenseView: View {
     
     init(expense: Expense?, receiptData: Data? = nil) {
         initialReceiptData = receiptData
+        let initialDate = expense?.date ?? .now
+        _date = State(initialValue: initialDate)
+        _initialDate = State(initialValue: initialDate)
         if let expense = expense {
             _name = State(initialValue: expense.name)
             _amount = State(initialValue: expense.amount)
@@ -123,7 +128,7 @@ struct AddExpenseView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button("Cancel") { dismiss() }
+                Button("Cancel") { requestDismissal() }
                     .accessibilityIdentifier("cancel-expense-button")
             }
             ToolbarItem(placement: .topBarTrailing) {
@@ -145,6 +150,15 @@ struct AddExpenseView: View {
         } message: {
             Text(errorMessage ?? "An unexpected error occurred")
         }
+        .confirmationDialog("Discard this expense?", isPresented: $showDiscardConfirmation, titleVisibility: .visible) {
+            Button("Discard Changes", role: .destructive) { dismiss() }
+                .accessibilityIdentifier("discard-expense-button")
+            Button("Keep Editing", role: .cancel) {}
+                .accessibilityIdentifier("keep-editing-expense-button")
+        } message: {
+            Text("Your unsaved expense details will be lost.")
+        }
+        .interactiveDismissDisabled(hasChanges)
         .photosPicker(
             isPresented: $showPhotoLibrary,
             selection: $receiptPhotoItem,
@@ -203,6 +217,14 @@ struct AddExpenseView: View {
 
     private var showsPastExpenseSuggestions: Bool {
         isNameFieldFocused && !pastExpenseSuggestions.isEmpty
+    }
+
+    private var hasChanges: Bool {
+        !name.isEmpty || amount != nil || !tags.isEmpty || !note.isEmpty || isRecurring || category != .needs || date != initialDate
+    }
+
+    private func requestDismissal() {
+        if hasChanges { showDiscardConfirmation = true } else { dismiss() }
     }
 
     private var pastExpenseSuggestionList: some View {

--- a/FinanceTracker/Views/Components/ExpenseDetailView.swift
+++ b/FinanceTracker/Views/Components/ExpenseDetailView.swift
@@ -24,6 +24,8 @@ struct ExpenseDetailView: View {
     @State private var saveErrorMessage: String?
     @State private var isSaving = false
     @State private var showingRecurringRuleConfirmation = false
+    @State private var showDiscardConfirmation = false
+    @State private var discardAction: (() -> Void)?
 
     private var recurringRule: RecurringExpenseRule? {
         guard let ruleID = expense.recurringExpenseId else { return nil }
@@ -60,7 +62,12 @@ struct ExpenseDetailView: View {
         .scrollDismissesKeyboard(.interactively)
         .navigationTitle("Edit Expense")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Back") { requestDismissal { dismiss() } }
+                    .accessibilityIdentifier("back-expense-button")
+            }
             ToolbarItem(placement: .confirmationAction) {
                 if isSaving {
                     ProgressView()
@@ -97,7 +104,45 @@ struct ExpenseDetailView: View {
         } message: {
             Text(saveErrorMessage ?? "Please try again.")
         }
+        .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirmation, titleVisibility: .visible) {
+            Button("Discard Changes", role: .destructive) {
+                let action = discardAction
+                discardAction = nil
+                action?()
+            }
+            .accessibilityIdentifier("discard-expense-changes-button")
+            Button("Keep Editing", role: .cancel) {}
+                .accessibilityIdentifier("keep-editing-expense-changes-button")
+        } message: {
+            Text("Your unsaved expense changes will be lost.")
+        }
+        .onAppear {
+            appRouter.expenseDraftNavigationHandler = { month in
+                requestDismissal { appRouter.completeShowExpenses(for: month) }
+            }
+        }
+        .onDisappear {
+            appRouter.expenseDraftNavigationHandler = nil
+        }
         .gradientBackground()
+    }
+
+    private var hasChanges: Bool {
+        workingExpense.name != expense.name
+            || workingExpense.amount != expense.amount
+            || workingExpense.date != expense.date
+            || workingExpense.category != expense.category
+            || workingExpense.note != expense.note
+            || workingExpense.tags.map(\.persistentModelID) != (expense.tags ?? []).map(\.persistentModelID)
+    }
+
+    private func requestDismissal(_ action: @escaping () -> Void) {
+        guard hasChanges else {
+            action()
+            return
+        }
+        discardAction = action
+        showDiscardConfirmation = true
     }
     
     private func saveItem(updateRecurringRule: Bool? = nil) async {

--- a/FinanceTracker/Views/SettingsView/Components/AddExpenseTagSheet.swift
+++ b/FinanceTracker/Views/SettingsView/Components/AddExpenseTagSheet.swift
@@ -33,6 +33,8 @@ struct AddExpenseTagSheet: View {
     /// icon is showing, so string-only surfaces (Shortcuts, entity subtitles) keep a mark and
     /// clearing the icon later restores something better than the default.
     @State private var fallbackEmoji: String = "💰"
+    @State private var showDiscardConfirmation = false
+    @State private var initialDraft: TagDraft?
 
     private var isEditing: Bool { tagToEdit != nil }
 
@@ -68,6 +70,12 @@ struct AddExpenseTagSheet: View {
     
     var body: some View {
         VStack(spacing: 24) {
+            HStack {
+                Button("Cancel") { requestDismissal() }
+                    .accessibilityIdentifier("cancel-tag-button")
+                Spacer()
+            }
+            .padding(.horizontal)
             Spacer()
 
             // Form fields
@@ -237,6 +245,15 @@ struct AddExpenseTagSheet: View {
         } message: {
             Text(saveErrorMessage ?? "Please try again.")
         }
+        .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirmation, titleVisibility: .visible) {
+            Button("Discard Changes", role: .destructive) { dismiss() }
+                .accessibilityIdentifier("discard-tag-button")
+            Button("Keep Editing", role: .cancel) {}
+                .accessibilityIdentifier("keep-editing-tag-button")
+        } message: {
+            Text("Your unsaved tag changes will be lost.")
+        }
+        .interactiveDismissDisabled(hasChanges)
         .onChange(of: glyph) { _, newValue in
             if case .emoji(let value) = newValue { fallbackEmoji = value }
         }
@@ -249,7 +266,34 @@ struct AddExpenseTagSheet: View {
                 hasBudget = tag.budget != nil
                 budgetText = tag.budget.map { AmountInput.text(for: $0) } ?? ""
             }
+            initialDraft = currentDraft
         }
+    }
+
+    private var currentDraft: TagDraft {
+        TagDraft(name: name, color: UIColor(color), glyph: glyph, hasBudget: hasBudget, budgetText: budgetText)
+    }
+
+    private var hasChanges: Bool {
+        guard let initialDraft else { return false }
+        return currentDraft != initialDraft
+    }
+
+    private func requestDismissal() {
+        if hasChanges { showDiscardConfirmation = true } else { dismiss() }
+    }
+}
+
+private struct TagDraft: Equatable {
+    let name: String
+    let color: UIColor
+    let glyph: TagGlyph
+    let hasBudget: Bool
+    let budgetText: String
+
+    static func == (lhs: TagDraft, rhs: TagDraft) -> Bool {
+        lhs.name == rhs.name && lhs.color.isEqual(rhs.color) && lhs.glyph == rhs.glyph
+            && lhs.hasBudget == rhs.hasBudget && lhs.budgetText == rhs.budgetText
     }
 }
 

--- a/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
+++ b/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
@@ -27,6 +27,7 @@ struct EditRecurringRuleSheet: View {
 
     @State private var showError = false
     @State private var errorMessage: String?
+    @State private var showDiscardConfirmation = false
 
     init(rule: RecurringExpenseRule) {
         self.rule = rule
@@ -111,7 +112,7 @@ struct EditRecurringRuleSheet: View {
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") { requestDismissal() }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Save") { saveChanges() }
@@ -128,7 +129,28 @@ struct EditRecurringRuleSheet: View {
             } message: {
                 Text("Use the Gregorian calendar in \(timeZoneIdentifier). Existing expenses and their identities stay unchanged. Past catch-up is skipped. Monthly rules already started resume after this month or the latest recorded occurrence's month, whichever is later. Other frequencies resume after that date on their cadence. Future start dates are kept. Update Syl on every synced device first; older versions do not honor this schedule.")
             }
+            .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirmation, titleVisibility: .visible) {
+                Button("Discard Changes", role: .destructive) { dismiss() }
+                    .accessibilityIdentifier("discard-recurring-rule-button")
+                Button("Keep Editing", role: .cancel) {}
+                    .accessibilityIdentifier("keep-editing-recurring-rule-button")
+            } message: {
+                Text("Your unsaved recurring expense changes will be lost.")
+            }
         }
+        .interactiveDismissDisabled(hasChanges)
+    }
+
+    private var hasChanges: Bool {
+        name != rule.name || amount != rule.amount || note != rule.note || category != rule.category
+            || tags.map(\.persistentModelID) != (rule.tags ?? []).map(\.persistentModelID)
+            || frequency != rule.frequency || hasEndDate != (rule.endDate != nil)
+            || (hasEndDate && endDate != rule.endDate)
+            || useFixedSchedule || timeZoneIdentifier != (rule.recurrenceTimeZoneIdentifier ?? TimeZone.current.identifier)
+    }
+
+    private func requestDismissal() {
+        if hasChanges { showDiscardConfirmation = true } else { dismiss() }
     }
 
     private func saveChanges(scheduleConfirmed: Bool = false) {


### PR DESCRIPTION
## Summary
- confirm before discarding changed expense, tag, and recurring-rule forms
- prevent changed sheet forms from swiping away and guard expense back navigation
- defer the Expenses stack reset through the active editor before Home Show All proceeds

## Testing
- `xcodebuild build -quiet -project FinanceTracker.xcodeproj -scheme FinanceTracker -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`\n\nCloses #60