### PR TITLE
Paginate expense search beyond 100 matches

### DIFF
--- a/APP_STORE_READINESS.md
+++ b/APP_STORE_READINESS.md
@@ -341,8 +341,11 @@ distribution, and App Store Connect checks remain open without execution evidenc
   [Stats UI tests](FinanceTrackerUITests/StatsViewUITests.swift).
 - [ ] **Add equivalent month navigation to Home and Expenses.** These still offer
   previous/next arrows only. Verify picker accessibility and presentation on device.
-- [ ] **Paginate search beyond 100 matches** or provide a way to reach older
-  results without guessing narrower search terms.
+- [x] **Paginate search beyond 100 matches.** Load more results reveals another
+  100 matches without changing search terms; a new query resets the visible window.
+  Sources: [Search](FinanceTracker/Views/ExpensesView/Components/SearchExpensesView.swift),
+  [search query tests](FinanceTrackerTests/ExpenseSearchPredicateTests.swift),
+  [pagination UI test](FinanceTrackerUITests/FinanceTrackerUITests.swift).
 - [x] **Explain overlapping tag totals in Stats.** Stats explains that expenses
   with multiple tags count toward each tag.
   Source: [Stats top tags](FinanceTracker/Views/StatsView/StatsView.swift).

--- a/FinanceTracker/Helpers/UITestConfiguration.swift
+++ b/FinanceTracker/Helpers/UITestConfiguration.swift
@@ -11,6 +11,7 @@ enum UITestConfiguration {
 
     static var isEnabled: Bool { environment["SAGE_UI_TESTING"] == "1" }
     static var showsOnboarding: Bool { environment["SAGE_UI_TEST_ONBOARDING"] == "1" }
+    static var seedsSearch: Bool { environment["SAGE_UI_TEST_SEED_SEARCH"] == "1" }
     static var seedsCalendar: Bool { environment["SAGE_UI_TEST_SEED_CALENDAR"] == "1" }
     static var seedExpenseName: String? { environment["SAGE_UI_TEST_SEED_EXPENSE"] }
 }

--- a/FinanceTracker/SageApp.swift
+++ b/FinanceTracker/SageApp.swift
@@ -42,6 +42,16 @@ struct SageApp: App {
                     )
                     try container.mainContext.save()
                 }
+                if UITestConfiguration.seedsSearch {
+                    let date = Date.now
+                    for index in 0..<101 {
+                        container.mainContext.insert(Expense(
+                            name: "Search Needle \(index)", amount: 1,
+                            date: date.addingTimeInterval(Double(-index))
+                        ))
+                    }
+                    try container.mainContext.save()
+                }
                 if UITestConfiguration.seedsCalendar {
                     let calendar = Calendar.current
                     let today = calendar.startOfDay(for: .now)

--- a/FinanceTracker/Views/ExpensesView/Components/SearchExpensesView.swift
+++ b/FinanceTracker/Views/ExpensesView/Components/SearchExpensesView.swift
@@ -32,7 +32,8 @@ struct SearchExpensesView: View {
                     Color.clear
                         .accessibilityHidden(true)
                 } else {
-                    ExpenseSearchResults(searchText: activeSearchText)
+                    PaginatedExpenseSearchResults(searchText: activeSearchText)
+                        .id(activeSearchText)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -61,28 +62,26 @@ struct SearchExpensesView: View {
     }
 }
 
-private struct ExpenseSearchResults: View {
-    private static let resultLimit = 100
-
-    @Query private var expenses: [Expense]
+private struct PaginatedExpenseSearchResults: View {
+    @State private var visibleLimit = 100
     let searchText: String
 
-    init(searchText: String) {
-        self.searchText = searchText
+    var body: some View {
+        ExpenseSearchResults(searchText: searchText, visibleLimit: visibleLimit) {
+            visibleLimit += 100
+        }
+    }
+}
 
-        let query = searchText
-        var descriptor = FetchDescriptor<Expense>(
-            predicate: #Predicate { expense in
-                expense.name.localizedStandardContains(query)
-                || expense.note.localizedStandardContains(query)
-                || (expense.tags?.contains { tag in
-                    tag.name.localizedStandardContains(query)
-                } == true)
-            },
-            sortBy: [SortDescriptor(\Expense.date, order: .reverse)]
-        )
-        descriptor.fetchLimit = Self.resultLimit
-        _expenses = Query(descriptor)
+private struct ExpenseSearchResults: View {
+    @Query private var expenses: [Expense]
+    let visibleLimit: Int
+    let loadMore: () -> Void
+
+    init(searchText: String, visibleLimit: Int, loadMore: @escaping () -> Void) {
+        self.visibleLimit = visibleLimit
+        self.loadMore = loadMore
+        _expenses = Query(ExpenseFetchDescriptors.search(searchText, visibleLimit: visibleLimit))
     }
 
     var body: some View {
@@ -105,11 +104,10 @@ private struct ExpenseSearchResults: View {
                         }
                     }
 
-                    if expenses.count == Self.resultLimit {
-                        Text("Showing the first \(Self.resultLimit) results")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
+                    if expenses.count > visibleLimit {
+                        Button("Load more results", action: loadMore)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .accessibilityIdentifier("search-load-more")
                     }
                 }
                 .scrollContentBackground(.hidden)
@@ -120,7 +118,7 @@ private struct ExpenseSearchResults: View {
 
     private func makeSections() -> [ExpenseSearchSection] {
         let calendar = Calendar.current
-        let groupedExpenses = Dictionary(grouping: expenses) { expense in
+        let groupedExpenses = Dictionary(grouping: expenses.prefix(visibleLimit)) { expense in
             calendar.startOfDay(for: expense.date)
         }
 

--- a/FinanceTrackerTests/ExpenseSearchPredicateTests.swift
+++ b/FinanceTrackerTests/ExpenseSearchPredicateTests.swift
@@ -15,18 +15,55 @@ struct ExpenseSearchPredicateTests {
         context.insert(expense)
         try context.save()
 
-        let query = "Grocer"
-        let descriptor = FetchDescriptor<Expense>(
-            predicate: #Predicate { expense in
-                expense.name.localizedStandardContains(query)
-                || expense.note.localizedStandardContains(query)
-                || (expense.tags?.contains { tag in
-                    tag.name.localizedStandardContains(query)
-                } == true)
-            }
-        )
+        let descriptor = ExpenseFetchDescriptors.search("Grocer", visibleLimit: 100)
 
         let matches = try context.fetch(descriptor)
         #expect(matches.map(\.id) == [expense.id])
+    }
+
+    @Test @MainActor
+    func reachesOlderMatchesAcrossMultiplePages() throws {
+        let container = try SageModelContainer.make(for: .test)
+        let context = container.mainContext
+        let newestDate = Date.now
+        var expected: [Expense] = []
+        for index in 0..<205 {
+            let expense = Expense(
+                name: "Needle \(index)", amount: 1,
+                date: newestDate.addingTimeInterval(Double(-index) * 86_400)
+            )
+            context.insert(expense)
+            expected.append(expense)
+        }
+        context.insert(Expense(name: "Unrelated", amount: 1))
+        try context.save()
+
+        for limit in [100, 200, 300] {
+            let matches = try context.fetch(ExpenseFetchDescriptors.search("Needle", visibleLimit: limit))
+            #expect(matches.count == min(limit + 1, expected.count))
+            #expect(matches.prefix(limit).map(\.id) == expected.prefix(limit).map(\.id))
+            #expect((matches.count > limit) == (limit < expected.count))
+        }
+        let changedQuery = try context.fetch(ExpenseFetchDescriptors.search("Unrelated", visibleLimit: 100))
+        #expect(changedQuery.map(\.name) == ["Unrelated"])
+        #expect(try context.fetch(ExpenseFetchDescriptors.search("Missing", visibleLimit: 100)).isEmpty)
+    }
+
+    @Test @MainActor
+    func exactPageHasNoExtraMatchAndReflectsDeletion() throws {
+        let container = try SageModelContainer.make(for: .test)
+        let context = container.mainContext
+        for _ in 0..<100 {
+            let expense = Expense(name: "Market", amount: 1)
+            expense.note = "Needle in a note"
+            context.insert(expense)
+        }
+        try context.save()
+        let descriptor = ExpenseFetchDescriptors.search("Needle", visibleLimit: 100)
+        let matches = try context.fetch(descriptor)
+        #expect(matches.count == 100)
+        context.delete(try #require(matches.first))
+        try context.save()
+        #expect(try context.fetch(descriptor).count == 99)
     }
 }

--- a/FinanceTrackerUITests/FinanceTrackerUITests.swift
+++ b/FinanceTrackerUITests/FinanceTrackerUITests.swift
@@ -622,6 +622,51 @@ final class FinanceTrackerUITests: XCTestCase {
         )
     }
 
+    func testSearchLoadsOlderResultsAndResetsForNewQuery() {
+        let app = XCUIApplication()
+        app.launchEnvironment["SAGE_UI_TESTING"] = "1"
+        app.launchEnvironment["SAGE_UI_TEST_ONBOARDING"] = "0"
+        app.launchEnvironment["SAGE_UI_TEST_SEED_SEARCH"] = "1"
+        app.launch()
+        let searchTab = app.tabBars.buttons["Search"]
+        XCTAssertTrue(searchTab.waitForExistence(timeout: timeout))
+        searchTab.tap()
+        let field = app.searchFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: timeout))
+        field.tap()
+        field.typeText("Needle")
+
+        let more = app.buttons["search-load-more"]
+        for _ in 0..<40 {
+            if more.exists && more.isHittable { break }
+            app.swipeUp()
+        }
+        XCTAssertTrue(more.isHittable)
+        more.tap()
+        let older = expenseRow(named: "Search Needle 100", in: app)
+        for _ in 0..<5 {
+            if older.exists && older.isHittable { break }
+            app.swipeUp()
+        }
+        XCTAssertTrue(older.isHittable, "The oldest match should become reachable after loading more.")
+        XCTAssertFalse(more.exists, "The final page should not offer more results.")
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Search - oldest result after loading more"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        field.tap()
+        field.typeText(" 100")
+        XCTAssertTrue(older.waitForExistence(timeout: timeout))
+        field.buttons["Clear text"].tap()
+        field.typeText("Needle")
+        for _ in 0..<40 {
+            if more.exists && more.isHittable { break }
+            app.swipeUp()
+        }
+        XCTAssertTrue(more.isHittable, "Changing the query must reset pagination to 100 results.")
+    }
+
     func testDeletesExpense() {
         let app = launchApp(seedExpense: "Expense to Delete")
         openExpenses(in: app)

--- a/SageKit/Services/ExpenseFetchDescriptors.swift
+++ b/SageKit/Services/ExpenseFetchDescriptors.swift
@@ -1,8 +1,26 @@
 import Foundation
 import SwiftData
 
-/// Shared persisted queries for category detail and dashboard spending.
+/// Shared persisted queries for expense lists and spending.
 public enum ExpenseFetchDescriptors {
+    /// Fetches the visible search window plus one match to detect another page.
+    /// Growing the window keeps SwiftData updates live without stale offset pages.
+    public static func search(_ query: String, visibleLimit: Int) -> FetchDescriptor<Expense> {
+        precondition(visibleLimit > 0 && visibleLimit < Int.max)
+        var descriptor = FetchDescriptor<Expense>(
+            predicate: #Predicate { expense in
+                expense.name.localizedStandardContains(query)
+                || expense.note.localizedStandardContains(query)
+                || (expense.tags?.contains { tag in
+                    tag.name.localizedStandardContains(query)
+                } == true)
+            },
+            sortBy: [SortDescriptor(\Expense.date, order: .reverse)]
+        )
+        descriptor.fetchLimit = visibleLimit + 1
+        return descriptor
+    }
+
     public static func month(_ month: Date, calendar: Calendar = .current) -> FetchDescriptor<Expense> {
         let interval = calendar.dateInterval(of: .month, for: month)
         return range(start: interval?.start ?? month, end: interval?.end ?? month)


### PR DESCRIPTION
Search previously stopped at 100 matches, leaving older expenses unreachable. Add a Load more results button that expands the live SwiftData query by 100 matches, fetches one extra match to detect the final page, and resets pagination when the search term changes. Update the readiness checklist.

Validation: targeted tests passed on iPhone 17 Pro, iOS 26.5 (FinanceTracker scheme):
- Three ExpenseSearchPredicateTests covering 205 matches across pages, name/note/tag matching, exact page size, empty results, and deletion.
- testSearchLoadsOlderResultsAndResetsForNewQuery verifies reaching the 101st match, hiding the final-page button, and resetting pagination.
- git diff --check passed. No full test suite was run.

The query retains the loaded window, so memory use grows as more results are requested. Physical-device and distribution verification were not performed.

Closes #71
