### PR TITLE
Respect Reduce Motion in toasts and form options

### DIFF
--- a/APP_STORE_READINESS.md
+++ b/APP_STORE_READINESS.md
@@ -360,10 +360,16 @@ distribution, and App Store Connect checks remain open without execution evidenc
   [gauge](FinanceTracker/Views/Components/ArcProgressGauge.swift),
   [circular gauge](FinanceTracker/Views/Components/CircularProgressBar.swift).
 
-- [ ] **Complete Reduce Motion support.** Audit explicit toast, budget-toggle,
-  recurring-option, and end-date animations. Keep native behavior and replace
-  unnecessary custom movement when Reduce Motion is enabled. Existing progress,
-  tag-selection, expense-date, and Stats month guards are already implemented.
+- [x] **Complete Reduce Motion support.** (#65) Audited the four remaining
+  surfaces against Apple's guidance. Toast presentation uses an opacity fade
+  under Reduce Motion; animation is owned by the overlay instead of the router.
+  Budget and end-date fields update without custom layout animation. Recurring
+  options retain their existing guard and explicitly remove the moving transition.
+  Native controls and existing progress, tag-selection, expense-date, and Stats
+  month guards are preserved. Evidence: source/diff review and the
+  [research, implementation decisions, and pending device checks](research/reduce-motion.md).
+  No local build or tests were run as requested; automated verification is
+  deferred to PR CI. Visual/device and release verification remain pending.
 
 - [ ] **Finish regional date and income input handling.** Older relative dates
   still use US ordering, and onboarding filters out non-ASCII digits. Use

--- a/FinanceTracker/Router/AppRouter.swift
+++ b/FinanceTracker/Router/AppRouter.swift
@@ -86,14 +86,15 @@ final class AppRouter {
 
     func showToast(_ toast: SageToast) {
         dismissTask?.cancel()
-        withAnimation(.spring(duration: 0.4)) { self.toast = toast }
+        // The presenting view owns animation so it can honor Reduce Motion.
+        self.toast = toast
 
         guard toast.kind != .progress else { return }
 
         dismissTask = Task { @MainActor in
             try? await Task.sleep(for: .seconds(3))
             guard !Task.isCancelled else { return }
-            withAnimation(.spring(duration: 0.4)) { self.toast = nil }
+            self.toast = nil
         }
     }
 }

--- a/FinanceTracker/Views/Components/AddExpenseView.swift
+++ b/FinanceTracker/Views/Components/AddExpenseView.swift
@@ -351,7 +351,7 @@ struct AddExpenseView: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .transition(reduceMotion ? .identity : .opacity.combined(with: .move(edge: .top)))
             }
 
         }

--- a/FinanceTracker/Views/RootTabView.swift
+++ b/FinanceTracker/Views/RootTabView.swift
@@ -10,6 +10,7 @@ import SwiftData
 import SageKit
 
 struct RootTabView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var appRouter = AppRouter()
     @State private var whatsNewRelease: WhatsNewRelease?
@@ -82,24 +83,29 @@ struct RootTabView: View {
             }
         }
         .overlay(alignment: .top) {
-            if let toast = appRouter.toast {
-                ToastPill(toast: toast)
-                    .padding(.top, 60)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                    .task {
-                        try? await Task.sleep(for: .milliseconds(700))
-                        let prefix: String
-                        switch toast.kind {
-                        case .progress: prefix = "In progress"
-                        case .success: prefix = "Success"
-                        case .error: prefix = "Error"
+            ZStack {
+                if let toast = appRouter.toast {
+                    ToastPill(toast: toast)
+                        .padding(.top, 60)
+                        .transition(reduceMotion ? .opacity : .move(edge: .top).combined(with: .opacity))
+                        .task {
+                            try? await Task.sleep(for: .milliseconds(700))
+                            let prefix: String
+                            switch toast.kind {
+                            case .progress: prefix = "In progress"
+                            case .success: prefix = "Success"
+                            case .error: prefix = "Error"
+                            }
+                            AccessibilityNotification.Announcement("\(prefix): \(toast.message)").post()
                         }
-                        AccessibilityNotification.Announcement("\(prefix): \(toast.message)").post()
-                    }
+                }
             }
+            .animation(
+                reduceMotion ? .easeOut(duration: 0.2) : .spring(duration: 0.4),
+                value: appRouter.toast == nil
+            )
         }
         .sensoryFeedback(.success, trigger: appRouter.toast?.kind == .success) { _, isSuccess in isSuccess }
-        .animation(.spring(duration: 0.4), value: appRouter.toast == nil)
         .environment(appRouter)
         .background(.background)
         .tint(.sage)

--- a/FinanceTracker/Views/SettingsView/Components/AddExpenseTagSheet.swift
+++ b/FinanceTracker/Views/SettingsView/Components/AddExpenseTagSheet.swift
@@ -13,6 +13,7 @@ struct AddExpenseTagSheet: View {
     @Environment(AppConfiguration.self) private var config
     @Environment(\.modelContext) var modelContext
     @Environment(\.dismiss) var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var tagToEdit: ExpenseTag? = nil
     var onTagAdded: ((ExpenseTag) -> Void)? = nil
@@ -233,7 +234,7 @@ struct AddExpenseTagSheet: View {
 
                 // Optional monthly budget
                 VStack(spacing: 10) {
-                    Toggle(isOn: $hasBudget.animation(.easeInOut(duration: 0.2))) {
+                    Toggle(isOn: $hasBudget) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Monthly Budget")
                                 .font(.subheadline)
@@ -262,7 +263,7 @@ struct AddExpenseTagSheet: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 10)
                         .background(RoundedRectangle(cornerRadius: 10).fill(.cardBackground))
-                        .transition(.opacity.combined(with: .move(edge: .top)))
+                        .transition(reduceMotion ? .identity : .opacity.combined(with: .move(edge: .top)))
                         if parsedBudget == nil {
                             Text(budgetValidationMessage)
                                 .font(.caption)
@@ -289,6 +290,7 @@ struct AddExpenseTagSheet: View {
             .animation(.easeInOut(duration: 0.2), value: glyph)
         }
         .padding(.bottom)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: hasBudget)
     }
 
     private var currentDraft: TagDraft {

--- a/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
+++ b/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
@@ -11,6 +11,7 @@ struct EditRecurringRuleSheet: View {
     @Environment(AppConfiguration.self) private var config
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let rule: RecurringExpenseRule
 
@@ -78,7 +79,7 @@ struct EditRecurringRuleSheet: View {
                             .tint(.primary)
                         }
 
-                        Toggle(isOn: $hasEndDate.animation()) {
+                        Toggle(isOn: $hasEndDate) {
                             Text("End Date")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
@@ -96,6 +97,7 @@ struct EditRecurringRuleSheet: View {
                     }
                     .padding(.horizontal)
                     .padding(.bottom, 8)
+                    .animation(reduceMotion ? nil : .default, value: hasEndDate)
                 }
             }
             .toolbar {

--- a/research/reduce-motion.md
+++ b/research/reduce-motion.md
@@ -1,0 +1,73 @@
+# Reduce Motion audit for #65
+
+Apple guidance reviewed before implementation on September 9, 2026:
+
+- [Accessibility HIG](https://developer.apple.com/design/human-interface-guidelines/accessibility):
+  reduce automatic, repetitive, and spatial motion; replace movement with fades.
+- [Reduced Motion evaluation criteria](https://developer.apple.com/help/app-store-connect/manage-app-accessibility/reduced-motion-evaluation-criteria):
+  evaluate each animation individually. Preserve meaningful feedback, using a
+  dissolve, highlight, or color change where appropriate. Decorative motion can
+  stop entirely; disabling every animation can hurt usability.
+- [SwiftUI accessibilityReduceMotion](https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityreducemotion):
+  read the system preference through the view environment. Avoid large animations,
+  especially simulated depth, when it is enabled.
+- [SwiftUI transactions](https://developer.apple.com/documentation/swiftui/transaction):
+  bindings and `withAnimation` supply animations to state updates. Based on this,
+  Sage keeps custom animation policy in the affected view instead of shared state.
+
+## Implementation decisions
+
+| Surface | Default motion | With Reduce Motion |
+| --- | --- | --- |
+| Toast appearance and dismissal | Existing 0.4-second spring and top-edge movement | 0.2-second opacity fade; no movement |
+| Tag monthly-budget fields | Existing 0.2-second ease-in/out and top-edge transition | Immediate insertion/removal; no animated layout or transition |
+| New expense recurring options | Existing 0.3-second spring and top-edge transition | Existing nil-animation guard retained; transition explicitly uses identity |
+| Recurring rule end-date picker | Existing default animation | Immediate insertion/removal; no custom layout animation |
+
+These are product choices for the four surfaces in #65, based on the guidance
+above. A short toast fade retains status feedback. The form's switch state and
+newly visible labeled fields make the result clear without animating their size
+or position. Native switches, pickers, sheets, navigation, and the toast's
+`ProgressView` remain system controls. There is no app-wide animation override.
+
+`RootTabView` owns toast presentation animation inside the overlay. `AppRouter`
+only changes toast state, cancels the previous dismissal task, and schedules
+the existing three-second dismissal for non-progress toasts. Replacing a visible
+toast updates its content immediately, avoiding a spring-driven size change.
+Progress messages still persist until replaced; success haptics and accessibility
+labels/announcements remain in place.
+
+The tag editor scopes budget animation to its editor content, and the recurring
+editor scopes end-date animation to its options. Each reads
+`@Environment(\.accessibilityReduceMotion)` so subsequent interactions and toast
+dismissal use the current preference, including after a Settings change. Existing
+progress, tag-selection, expense-date, and Stats month guards are outside this
+issue's remaining scope and are preserved.
+
+## Evidence and pending verification
+
+Implementation evidence:
+
+- [Toast state](../FinanceTracker/Router/AppRouter.swift) and
+  [presentation](../FinanceTracker/Views/RootTabView.swift).
+- [Budget editor](../FinanceTracker/Views/SettingsView/Components/AddExpenseTagSheet.swift),
+  [recurring options](../FinanceTracker/Views/Components/AddExpenseView.swift), and
+  [end-date editor](../FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift).
+
+Source and diff review only. No local build, automated tests, or simulator/device
+tests were run, as requested; build and automated test results belong to PR CI.
+The existing CI does not replace visual motion verification. Device/release
+verification remains pending, including:
+
+- With Reduce Motion off and on, show success/error toasts and replace a progress
+  toast. Check presentation, replacement, three-second dismissal, and persistence
+  of progress feedback. Change the setting while a toast is visible and check its
+  dismissal uses the new preference.
+- Toggle Monthly Budget, Recurring, and End Date in both modes. Check all fields
+  remain usable, toggling off/on retains draft values, and saved values are
+  unaffected. Change the setting while each editor is open and repeat.
+- Check native sheets, pickers, switches, navigation, toast announcements, and
+  success haptics on the supported iPhone/iPad configurations.
+
+Completing this source audit does not establish release-device verification or
+an App Store accessibility-support claim.


### PR DESCRIPTION
Reduce Motion users still received a sliding spring toast and animated layout changes when toggling a tag budget or recurring end date. Toasts now use a short opacity fade, and budget, recurring-option, and end-date fields update without custom movement when the system preference is enabled. Native controls remain system-managed.

Toast animation now belongs to its overlay instead of shared router mutations. Default entrance/exit motion and dismissal timing are preserved; replacing a visible toast updates its content immediately. The readiness checklist links the implementation decisions, Apple research, and pending device checks.

Research completed before implementation: [Apple Accessibility HIG](https://developer.apple.com/design/human-interface-guidelines/accessibility), [Reduced Motion evaluation criteria](https://developer.apple.com/help/app-store-connect/manage-app-accessibility/reduced-motion-evaluation-criteria), and [SwiftUI environment guidance](https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityreducemotion). Decisions and source links are recorded in [research/reduce-motion.md](research/reduce-motion.md).

Validation: reviewed the source and final diff; `git diff --check` and staged diff checks passed. No local build or tests were run, per request. Build and automated tests are delegated to PR CI. Visual/device verification with Reduce Motion off/on and changed while a toast/editor is visible remains pending; the research note records those checks.

Closes #65
