### PR TITLE
Constrain oversized tag chips

### DIFF
--- a/APP_STORE_READINESS.md
+++ b/APP_STORE_READINESS.md
@@ -346,11 +346,19 @@ distribution, and App Store Connect checks remain open without execution evidenc
   Sources: [tag picker](FinanceTracker/Views/Components/TagPicker.swift),
   [gauge](FinanceTracker/Views/Components/ArcProgressGauge.swift).
 
-- [ ] **Constrain oversized tag chips.** Flow layout measures children at
-  unconstrained intrinsic width. Long names or accessibility text sizes can
-  overflow the available width. Measure oversized children with a width bound
-  and account for their resulting height.
-  Source: [FlowLayout](FinanceTracker/Views/Components/FlowLayout.swift).
+- [x] **Constrain oversized tag chips.** (#63) Oversized children are remeasured
+  with the available width and unrestricted height. Row sizing and placement use
+  those constrained sizes and proposals, preserving wrapped text and spacing.
+  Unspecified or infinite widths use the natural content width.
+  Evidence: simulator build succeeded; four focused layout tests and two picker
+  UI tests passed on iPhone 17 Pro (iOS 26.5). Coverage includes long names,
+  normal and accessibility XL text, leading/center alignment, exact-fit rows,
+  empty content, and selecting/deselecting the real tag capsule. Light/dark
+  screenshots and sampled recording frames were reviewed. Verification is
+  simulator-only; physical-device and distribution checks remain outstanding.
+  Sources: [FlowLayout](FinanceTracker/Views/Components/FlowLayout.swift),
+  [layout tests](FinanceTrackerTests/Views/FlowLayoutTests.swift),
+  [picker UI tests](FinanceTrackerUITests/Settings/TagEditorUITests.swift).
 
 - [ ] **Represent zero budgets and over-budget values accurately.** Positive
   spending against zero allocation or income should not say 0% used. Arc-gauge

--- a/FinanceTracker.xcodeproj/project.pbxproj
+++ b/FinanceTracker.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 				Services/RecurringExpenses/RecurringExpenseRepairService.swift,
 				Services/RecurringExpenses/RecurringExpenseSchedule.swift,
 				Services/RecurringExpenses/RecurringExpenseService.swift,
+				Views/Components/FlowLayout.swift,
 			);
 			target = C62400062FFF002400000006 /* FinanceTrackerTests */;
 		};

--- a/FinanceTracker/Views/Components/FlowLayout.swift
+++ b/FinanceTracker/Views/Components/FlowLayout.swift
@@ -14,42 +14,65 @@ struct FlowLayout: Layout {
     var alignment: HorizontalAlignment = .center
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let rows = computeRows(proposal: proposal, subviews: subviews)
-        let height = rows.map { row in row.map { $0.sizeThatFits(.unspecified).height }.max() ?? 0 }.reduce(0) { $0 + $1 + spacing } - spacing
-        return CGSize(width: proposal.width ?? 0, height: max(0, height))
+        let width = finiteWidth(proposal.width)
+        let rows = computeRows(maxWidth: width, subviews: subviews)
+        let height = rows.reduce(0) { $0 + $1.height } + CGFloat(max(0, rows.count - 1)) * spacing
+        return CGSize(width: width ?? rows.map(\.width).max() ?? 0, height: height)
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let rows = computeRows(proposal: proposal, subviews: subviews)
+        let rows = computeRows(maxWidth: finiteWidth(bounds.width), subviews: subviews)
         var y = bounds.minY
         for row in rows {
-            let rowHeight = row.map { $0.sizeThatFits(.unspecified).height }.max() ?? 0
-            let rowWidth = row.map { $0.sizeThatFits(.unspecified).width }.reduce(0) { $0 + $1 + spacing } - spacing
-            var x = alignment == .leading ? bounds.minX : bounds.minX + (bounds.width - rowWidth) / 2
-            for subview in row {
-                let size = subview.sizeThatFits(.unspecified)
-                subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
-                x += size.width + spacing
+            var x = alignment == .leading ? bounds.minX : bounds.minX + (bounds.width - row.width) / 2
+            for item in row.items {
+                item.subview.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: item.proposal)
+                x += item.size.width + spacing
             }
-            y += rowHeight + spacing
+            y += row.height + spacing
         }
     }
 
-    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[LayoutSubview]] {
-        let maxWidth = proposal.width ?? .infinity
-        var rows: [[LayoutSubview]] = [[]]
-        var rowWidth: CGFloat = 0
+    private struct Item {
+        let subview: LayoutSubview
+        let size: CGSize
+        let proposal: ProposedViewSize
+    }
+
+    private struct Row {
+        var items: [Item] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func finiteWidth(_ width: CGFloat?) -> CGFloat? {
+        guard let width, width.isFinite else { return nil }
+        return max(0, width)
+    }
+
+    private func computeRows(maxWidth: CGFloat?, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var row = Row()
 
         for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if rowWidth + size.width > maxWidth, !rows[rows.endIndex - 1].isEmpty {
-                rows.append([subview])
-                rowWidth = size.width + spacing
-            } else {
-                rows[rows.endIndex - 1].append(subview)
-                rowWidth += size.width + spacing
+            var proposal = ProposedViewSize.unspecified
+            var size = subview.sizeThatFits(proposal)
+            if let maxWidth, size.width > maxWidth {
+                // Allow a long chip to wrap vertically, then retain that measurement and
+                // proposal so row height and placement describe the same rendered content.
+                proposal = ProposedViewSize(width: maxWidth, height: nil)
+                size = subview.sizeThatFits(proposal)
             }
+            let gap = row.items.isEmpty ? 0 : spacing
+            if !row.items.isEmpty, row.width + gap + size.width > (maxWidth ?? .infinity) {
+                rows.append(row)
+                row = Row()
+            }
+            row.width += (row.items.isEmpty ? 0 : spacing) + size.width
+            row.height = max(row.height, size.height)
+            row.items.append(Item(subview: subview, size: size, proposal: proposal))
         }
+        if !row.items.isEmpty { rows.append(row) }
         return rows
     }
 }

--- a/FinanceTrackerTests/Views/FlowLayoutTests.swift
+++ b/FinanceTrackerTests/Views/FlowLayoutTests.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import UIKit
+import XCTest
+
+@MainActor
+final class FlowLayoutTests: XCTestCase {
+    func testOversizedChipsWrapAndReserveTheirFullHeight() async throws {
+        for dynamicType in [DynamicTypeSize.large, .accessibility3] {
+            for alignment in [HorizontalAlignment.leading, .center] {
+                let frames = Frames()
+                let names = ["Short", "A very long tag name that must wrap across several lines", "Next"]
+                let content = FlowLayout(spacing: 8, alignment: alignment) {
+                    ForEach(names.indices, id: \.self) { index in
+                        Button {} label: {
+                            Text(names[index])
+                                .font(.subheadline)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Capsule().fill(.green.opacity(0.2)))
+                        }
+                        .buttonStyle(.plain)
+                        .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("flow")) } action: {
+                            frames.items[index] = $0
+                        }
+                    }
+                }
+                .coordinateSpace(name: "flow")
+                .environment(\.dynamicTypeSize, dynamicType)
+
+                let host = UIHostingController(rootView: content)
+                let size = host.sizeThatFits(in: CGSize(width: 240, height: CGFloat.greatestFiniteMagnitude))
+                let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+                window.rootViewController = host
+                window.makeKeyAndVisible()
+                defer { window.isHidden = true }
+                host.view.frame = window.bounds
+                host.view.setNeedsLayout()
+                host.view.layoutIfNeeded()
+                // Geometry callbacks arrive on the next SwiftUI update.
+                let ready = XCTNSPredicateExpectation(predicate: NSPredicate { _, _ in
+                    frames.items.count == names.count
+                }, object: nil)
+                await fulfillment(of: [ready], timeout: 5)
+
+                let first = try XCTUnwrap(frames.items[0])
+                let long = try XCTUnwrap(frames.items[1])
+                let next = try XCTUnwrap(frames.items[2])
+                for frame in frames.items.values {
+                    XCTAssertGreaterThanOrEqual(frame.minX, -0.5)
+                    XCTAssertLessThanOrEqual(frame.maxX, 240.5)
+                }
+                XCTAssertGreaterThan(long.height, first.height)
+                XCTAssertEqual(long.minY, first.maxY + 8, accuracy: 0.5)
+                XCTAssertEqual(next.minY, long.maxY + 8, accuracy: 0.5)
+                XCTAssertEqual(size.height, next.maxY, accuracy: 0.5)
+                let expectedX = alignment == .leading ? 0 : (240 - next.width) / 2
+                XCTAssertEqual(next.minX, expectedX, accuracy: 0.5)
+            }
+        }
+    }
+
+    func testOrdinaryChipsFitExactlyAndRowsUseTheTallestChild() {
+        let host = UIHostingController(rootView: FlowLayout(spacing: 8) {
+            Color.clear.frame(width: 80, height: 20)
+            Color.clear.frame(width: 112, height: 35)
+            Color.clear.frame(width: 60, height: 15)
+        })
+        let size = host.sizeThatFits(in: CGSize(width: 200, height: CGFloat.greatestFiniteMagnitude))
+        XCTAssertEqual(size.width, 200)
+        XCTAssertEqual(size.height, 35 + 8 + 15)
+    }
+
+    func testUnspecifiedWidthUsesTheNaturalRowWidth() {
+        let host = UIHostingController(rootView: FlowLayout(spacing: 8) {
+            Color.clear.frame(width: 80, height: 20)
+            Color.clear.frame(width: 112, height: 35)
+        }.fixedSize())
+        let size = host.sizeThatFits(in: CGSize(width: 300, height: 300))
+        XCTAssertEqual(size, CGSize(width: 200, height: 35))
+    }
+
+    func testEmptyLayoutHasNoRowSpacing() {
+        let host = UIHostingController(rootView: FlowLayout { EmptyView() })
+        let size = host.sizeThatFits(in: CGSize(width: 240, height: 300))
+        XCTAssertEqual(size, CGSize(width: 240, height: 0))
+    }
+
+    private final class Frames {
+        var items: [Int: CGRect] = [:]
+    }
+}

--- a/FinanceTrackerUITests/Settings/TagEditorUITests.swift
+++ b/FinanceTrackerUITests/Settings/TagEditorUITests.swift
@@ -91,6 +91,49 @@ final class TagEditorUITests: XCTestCase {
         XCTAssertTrue(glyph.waitForNonExistence(timeout: timeout))
     }
 
+    func testLongTagFitsPickerAndCanBeSelected() {
+        verifyLongTagPicker(dark: false)
+    }
+
+    func testLongTagFitsPickerWithAccessibilityText() {
+        verifyLongTagPicker(dark: true)
+    }
+
+    private func verifyLongTagPicker(dark: Bool) {
+        let app = openTagEditor(dark: dark)
+        let name = "Weekend groceries and household supplies for the whole family"
+        let nameField = app.textFields["Tag Name"]
+        tap(nameField)
+        nameField.typeText(name)
+        tap(app.buttons["Add Tag"])
+        XCTAssertTrue(nameField.waitForNonExistence(timeout: timeout))
+        tap(app.navigationBars.buttons.firstMatch)
+        tap(app.tabBars.buttons["Expenses"])
+        tap(app.descendants(matching: .any)["add-expense-button"].firstMatch)
+        XCTAssertTrue(app.textFields["expense-name-field"].waitForExistence(timeout: timeout))
+        tap(app.buttons["expense-keyboard-continue-button"])
+        tap(app.buttons["expense-keyboard-continue-button"])
+
+        let chip = app.buttons["Tag: \(name)"]
+        reveal(chip, in: app)
+        let screen = app.windows.firstMatch.frame
+        XCTAssertGreaterThanOrEqual(chip.frame.minX, screen.minX)
+        XCTAssertLessThanOrEqual(chip.frame.maxX, screen.maxX)
+        XCTAssertGreaterThan(chip.frame.height, dark ? 80 : 40, "The long tag should wrap, not truncate.")
+        let addTag = app.buttons.containing(.staticText, identifier: "Add new tag").firstMatch
+        reveal(addTag, in: app)
+        XCTAssertGreaterThanOrEqual(addTag.frame.minY, chip.frame.maxY)
+        screenshot(dark ? "Long tag - dark accessibility XL" : "Long tag - light default text", in: app)
+
+        reveal(chip, in: app)
+        tap(chip)
+        XCTAssertEqual(chip.value as? String, "Selected")
+        tap(chip)
+        XCTAssertEqual(chip.value as? String, "Not selected")
+        tap(app.buttons["cancel-expense-button"])
+        XCTAssertTrue(app.textFields["expense-name-field"].waitForNonExistence(timeout: timeout))
+    }
+
     private func openTagEditor(dark: Bool) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["SAGE_UI_TESTING"] = "1"


### PR DESCRIPTION
Long tag names and accessibility text sizes could overflow the tag picker because FlowLayout always measured children at their unconstrained width. Oversized chips now receive the available width with unrestricted height, and row sizing and placement use the resulting measurements and proposals. Unconstrained layouts report their natural content width.

Added layout regression coverage and picker UI checks for long labels, selection, and deselection in light/default text and dark/accessibility XL appearances. Updated the readiness checklist for #63.

Validation: Sage built successfully on the iPhone 17 Pro simulator (iOS 26.5). All four FlowLayoutTests and both new TagEditorUITests passed. Reviewed screenshots and sampled recording frames; git diff --check passed. Physical-device and distribution verification was not performed.

Closes #63
